### PR TITLE
Add optional failed.html support for post-capture redirect

### DIFF
--- a/flipper/flipper-evil-portal/evil_portal_app.c
+++ b/flipper/flipper-evil-portal/evil_portal_app.c
@@ -29,9 +29,18 @@ Evil_PortalApp *evil_portal_app_alloc() {
   app->sent_html = false;
   app->sent_ap = false;
   app->sent_reset = false;
-  app->has_command_queue = false;  
+  app->has_command_queue = false;
   app->command_index = 0;
+  app->command_queue_length = 0;
+  app->failed_html = NULL;
+  app->has_failed_html = false;
+  app->index_html = NULL;
+  app->ap_name = NULL;
   app->portal_logs = furi_string_alloc();
+
+  for (size_t i = 0; i < COMMAND_QUEUE_SIZE; ++i) {
+    app->command_queue[i] = NULL;
+  }
 
   app->gui = furi_record_open(RECORD_GUI);
 
@@ -70,12 +79,27 @@ Evil_PortalApp *evil_portal_app_alloc() {
   return app;
 }
 
-void evil_portal_app_free(Evil_PortalApp *app) {  
+void evil_portal_app_free(Evil_PortalApp *app) {
 
   // save latest logs
   if (furi_string_utf8_length(app->portal_logs) > 0) {
     write_logs(app->portal_logs);
-    furi_string_free(app->portal_logs);
+  }
+  furi_string_free(app->portal_logs);
+
+  if (app->failed_html) {
+    free(app->failed_html);
+    app->failed_html = NULL;
+  }
+
+  if (app->index_html) {
+    free(app->index_html);
+    app->index_html = NULL;
+  }
+
+  if (app->ap_name) {
+    free(app->ap_name);
+    app->ap_name = NULL;
   }
 
   // Send reset event to dev board

--- a/flipper/flipper-evil-portal/evil_portal_app_i.h
+++ b/flipper/flipper-evil-portal/evil_portal_app_i.h
@@ -10,13 +10,17 @@
 #include <gui/modules/variable_item_list.h>
 #include <gui/scene_manager.h>
 #include <gui/view_dispatcher.h>
+#include <furi.h>
+#include <furi_hal.h>
 
 #define NUM_MENU_ITEMS (4)
+#define COMMAND_QUEUE_SIZE (2)
 
 #define EVIL_PORTAL_TEXT_BOX_STORE_SIZE (4096)
 #define UART_CH (FuriHalUartIdUSART1)
 
 #define SET_HTML_CMD "sethtml"
+#define SET_FAILED_CMD "setfailed"
 #define SET_AP_CMD "setap"
 #define RESET_CMD "reset"
 
@@ -26,8 +30,9 @@ struct Evil_PortalApp {
   SceneManager *scene_manager;
 
   FuriString* portal_logs;
-  const char *command_queue[1];
+  const char *command_queue[COMMAND_QUEUE_SIZE];
   int command_index;
+  size_t command_queue_length;
   bool has_command_queue;
 
   FuriString *text_box_store;
@@ -51,6 +56,8 @@ struct Evil_PortalApp {
 
   uint8_t *index_html;
   uint8_t *ap_name;
+  uint8_t *failed_html;
+  bool has_failed_html;
 };
 
 typedef enum {

--- a/flipper/flipper-evil-portal/helpers/evil_portal_storage.c
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_storage.c
@@ -1,10 +1,28 @@
 #include "evil_portal_storage.h"
 
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
 static Storage *evil_portal_open_storage() {
   return furi_record_open(RECORD_STORAGE);
 }
 
 static void evil_portal_close_storage() { furi_record_close(RECORD_STORAGE); }
+
+static uint8_t *evil_portal_strdup_safe(const char *text) {
+  if (!text) {
+    text = "";
+  }
+
+  size_t len = strlen(text);
+  char *copy = malloc(len + 1);
+  if (copy) {
+    memcpy(copy, text, len + 1);
+  }
+
+  return (uint8_t *)copy;
+}
 
 void evil_portal_read_index_html(void *context) {
 
@@ -12,34 +30,109 @@ void evil_portal_read_index_html(void *context) {
   Storage *storage = evil_portal_open_storage();
   FileInfo fi;
 
-  if (storage_common_stat(storage, EVIL_PORTAL_INDEX_SAVE_PATH, &fi) ==
-      FSE_OK) {
+  if (app->index_html) {
+    free(app->index_html);
+    app->index_html = NULL;
+  }
+
+  bool loaded = false;
+
+  if (storage_common_stat(storage, EVIL_PORTAL_INDEX_SAVE_PATH, &fi) == FSE_OK &&
+      fi.size > 0) {
     File *index_html = storage_file_alloc(storage);
-    if (storage_file_open(index_html, EVIL_PORTAL_INDEX_SAVE_PATH, FSAM_READ,
-                          FSOM_OPEN_EXISTING)) {
-      app->index_html = malloc((size_t)fi.size);
-      uint8_t *buf_ptr = app->index_html;
-      size_t read = 0;
-      while (read < fi.size) {
-        size_t to_read = fi.size - read;
-        if (to_read > UINT16_MAX)
-          to_read = UINT16_MAX;
-        uint16_t now_read =
-            storage_file_read(index_html, buf_ptr, (uint16_t)to_read);
-        read += now_read;
-        buf_ptr += now_read;
+    if (index_html) {
+      bool file_opened =
+          storage_file_open(index_html, EVIL_PORTAL_INDEX_SAVE_PATH, FSAM_READ,
+                            FSOM_OPEN_EXISTING);
+      if (file_opened) {
+        size_t buffer_size = (size_t)fi.size;
+        uint8_t *buffer = malloc(buffer_size + 1);
+        if (buffer) {
+          size_t read = 0;
+          while (read < buffer_size) {
+            size_t to_read = buffer_size - read;
+            if (to_read > UINT16_MAX) {
+              to_read = UINT16_MAX;
+            }
+            uint16_t now_read =
+                storage_file_read(index_html, buffer + read, (uint16_t)to_read);
+            if (now_read == 0) {
+              break;
+            }
+            read += now_read;
+          }
+          buffer[read] = '\0';
+          if (read > 0) {
+            app->index_html = buffer;
+            loaded = true;
+          } else {
+            free(buffer);
+          }
+        }
+        storage_file_close(index_html);
       }
-      free(buf_ptr);
+      storage_file_free(index_html);
     }
-    storage_file_close(index_html);
-    storage_file_free(index_html);
-  } else {
-    char *html_error =
+  }
+
+  if (!loaded) {
+    const char *html_error =
         "<b>Evil portal</b><br>Unable to read the html file.<br>"
         "Is the SD Card set up correctly? <br>See instructions @ "
         "github.com/bigbrodude6119/flipper-zero-evil-portal<br>"
         "Under the 'Install pre-built app on the flipper' section.";
-    app->index_html = (uint8_t *)html_error;
+    app->index_html = evil_portal_strdup_safe(html_error);
+  }
+
+  evil_portal_close_storage();
+}
+
+void evil_portal_read_failed_html(void *context) {
+
+  Evil_PortalApp *app = context;
+  Storage *storage = evil_portal_open_storage();
+  FileInfo fi;
+
+  if (app->failed_html) {
+    free(app->failed_html);
+    app->failed_html = NULL;
+  }
+  app->has_failed_html = false;
+
+  if (storage_common_stat(storage, EVIL_PORTAL_FAILED_SAVE_PATH, &fi) == FSE_OK &&
+      fi.size > 0) {
+    File *failed_html = storage_file_alloc(storage);
+    if (failed_html) {
+      bool file_opened = storage_file_open(failed_html, EVIL_PORTAL_FAILED_SAVE_PATH,
+                                           FSAM_READ, FSOM_OPEN_EXISTING);
+      if (file_opened) {
+        size_t buffer_size = (size_t)fi.size;
+        app->failed_html = malloc(buffer_size + 1);
+        if (app->failed_html) {
+          size_t read = 0;
+          while (read < buffer_size) {
+            size_t to_read = buffer_size - read;
+            if (to_read > UINT16_MAX)
+              to_read = UINT16_MAX;
+            uint16_t now_read = storage_file_read(
+                failed_html, app->failed_html + read, (uint16_t)to_read);
+            if (now_read == 0)
+              break;
+            read += now_read;
+          }
+          app->failed_html[read] = '\0';
+          app->has_failed_html = (read > 0);
+          if (!app->has_failed_html) {
+            free(app->failed_html);
+            app->failed_html = NULL;
+          }
+        }
+      }
+      if (file_opened) {
+        storage_file_close(failed_html);
+      }
+      storage_file_free(failed_html);
+    }
   }
 
   evil_portal_close_storage();
@@ -50,29 +143,52 @@ void evil_portal_read_ap_name(void *context) {
   Storage *storage = evil_portal_open_storage();
   FileInfo fi;
 
-  if (storage_common_stat(storage, EVIL_PORTAL_AP_SAVE_PATH, &fi) == FSE_OK) {
+  if (app->ap_name) {
+    free(app->ap_name);
+    app->ap_name = NULL;
+  }
+
+  bool loaded = false;
+
+  if (storage_common_stat(storage, EVIL_PORTAL_AP_SAVE_PATH, &fi) == FSE_OK &&
+      fi.size > 0) {
     File *ap_name = storage_file_alloc(storage);
-    if (storage_file_open(ap_name, EVIL_PORTAL_AP_SAVE_PATH, FSAM_READ,
-                          FSOM_OPEN_EXISTING)) {
-      app->ap_name = malloc((size_t)fi.size);
-      uint8_t *buf_ptr = app->ap_name;
-      size_t read = 0;
-      while (read < fi.size) {
-        size_t to_read = fi.size - read;
-        if (to_read > UINT16_MAX)
-          to_read = UINT16_MAX;
-        uint16_t now_read =
-            storage_file_read(ap_name, buf_ptr, (uint16_t)to_read);
-        read += now_read;
-        buf_ptr += now_read;
+    if (ap_name) {
+      bool file_opened = storage_file_open(ap_name, EVIL_PORTAL_AP_SAVE_PATH,
+                                           FSAM_READ, FSOM_OPEN_EXISTING);
+      if (file_opened) {
+        size_t buffer_size = (size_t)fi.size;
+        uint8_t *buffer = malloc(buffer_size + 1);
+        if (buffer) {
+          size_t read = 0;
+          while (read < buffer_size) {
+            size_t to_read = buffer_size - read;
+            if (to_read > UINT16_MAX) {
+              to_read = UINT16_MAX;
+            }
+            uint16_t now_read =
+                storage_file_read(ap_name, buffer + read, (uint16_t)to_read);
+            if (now_read == 0) {
+              break;
+            }
+            read += now_read;
+          }
+          buffer[read] = '\0';
+          if (read > 0) {
+            app->ap_name = buffer;
+            loaded = true;
+          } else {
+            free(buffer);
+          }
+        }
+        storage_file_close(ap_name);
       }
-      free(buf_ptr);
+      storage_file_free(ap_name);
     }
-    storage_file_close(ap_name);
-    storage_file_free(ap_name);
-  } else {
-    char *app_default = "Evil Portal";
-    app->ap_name = (uint8_t *)app_default;
+  }
+
+  if (!loaded) {
+    app->ap_name = evil_portal_strdup_safe("Evil Portal");
   }
   evil_portal_close_storage();
 }
@@ -94,7 +210,12 @@ char *sequential_file_resolve_path(Storage *storage, const char *dir,
     file_index++;
   } while (storage_file_exists(storage, file_path));
 
-  return strdup(file_path);
+  size_t path_len = strlen(file_path);
+  char *result = malloc(path_len + 1);
+  if (result) {
+    memcpy(result, file_path, path_len + 1);
+  }
+  return result;
 }
 
 void write_logs(FuriString *portal_logs) {
@@ -107,12 +228,17 @@ void write_logs(FuriString *portal_logs) {
   char *seq_file_path = sequential_file_resolve_path(
       storage, EVIL_PORTAL_LOG_SAVE_PATH, "log", "txt");
 
-  File *file = storage_file_alloc(storage);
-
-  if (storage_file_open(file, seq_file_path, FSAM_WRITE, FSOM_CREATE_ALWAYS)) {
-    storage_file_write(file, furi_string_get_cstr(portal_logs), furi_string_utf8_length(portal_logs));
+  if (seq_file_path) {
+    File *file = storage_file_alloc(storage);
+    if (file) {
+      if (storage_file_open(file, seq_file_path, FSAM_WRITE, FSOM_CREATE_ALWAYS)) {
+        storage_file_write(file, furi_string_get_cstr(portal_logs),
+                           furi_string_utf8_length(portal_logs));
+        storage_file_close(file);
+      }
+      storage_file_free(file);
+    }
+    free(seq_file_path);
   }
-  storage_file_close(file);
-  storage_file_free(file);
   evil_portal_close_storage();
 }

--- a/flipper/flipper-evil-portal/helpers/evil_portal_storage.h
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_storage.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "../evil_portal_app_i.h"
 #include <flipper_format/flipper_format_i.h>
 #include <lib/toolbox/stream/file_stream.h>
@@ -7,10 +9,12 @@
 
 #define PORTAL_FILE_DIRECTORY_PATH EXT_PATH("apps_data/evil_portal")
 #define EVIL_PORTAL_INDEX_SAVE_PATH PORTAL_FILE_DIRECTORY_PATH "/index.html"
+#define EVIL_PORTAL_FAILED_SAVE_PATH PORTAL_FILE_DIRECTORY_PATH "/failed.html"
 #define EVIL_PORTAL_AP_SAVE_PATH PORTAL_FILE_DIRECTORY_PATH "/ap.config.txt"
 #define EVIL_PORTAL_LOG_SAVE_PATH PORTAL_FILE_DIRECTORY_PATH "/logs"
 
 void evil_portal_read_index_html(void *context);
+void evil_portal_read_failed_html(void *context);
 void evil_portal_read_ap_name(void *context);
 void write_logs(FuriString* portal_logs);
 char *sequential_file_resolve_path(Storage *storage, const char *dir,

--- a/tests/compilation_stubs/flipper_format/flipper_format_i.h
+++ b/tests/compilation_stubs/flipper_format/flipper_format_i.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/tests/compilation_stubs/furi.h
+++ b/tests/compilation_stubs/furi.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct FuriString FuriString;
+
+#define RECORD_STORAGE "storage"
+
+void *furi_record_open(const char *record_name);
+void furi_record_close(const char *record_name);
+size_t furi_string_utf8_length(const FuriString *str);
+const char *furi_string_get_cstr(const FuriString *str);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/compilation_stubs/furi_hal.h
+++ b/tests/compilation_stubs/furi_hal.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+
+typedef enum {
+  FuriHalUartIdUSART1 = 0,
+} FuriHalUartId;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void furi_hal_uart_tx(FuriHalUartId channel, const uint8_t *data, size_t size);
+void furi_hal_uart_set_br(FuriHalUartId channel, uint32_t baudrate);
+void furi_hal_uart_set_irq_cb(FuriHalUartId channel,
+                              void (*callback)(uint8_t event, uint8_t data,
+                                               void *context),
+                              void *context);
+void furi_hal_console_disable(void);
+void furi_hal_console_enable(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/compilation_stubs/gui/gui.h
+++ b/tests/compilation_stubs/gui/gui.h
@@ -1,0 +1,3 @@
+#pragma once
+
+typedef struct Gui Gui;

--- a/tests/compilation_stubs/gui/modules/text_box.h
+++ b/tests/compilation_stubs/gui/modules/text_box.h
@@ -1,0 +1,12 @@
+#pragma once
+
+typedef struct TextBox TextBox;
+
+typedef enum {
+  TextBoxFontText = 0,
+} TextBoxFont;
+
+typedef enum {
+  TextBoxFocusStart = 0,
+  TextBoxFocusEnd,
+} TextBoxFocus;

--- a/tests/compilation_stubs/gui/modules/variable_item_list.h
+++ b/tests/compilation_stubs/gui/modules/variable_item_list.h
@@ -1,0 +1,3 @@
+#pragma once
+
+typedef struct VariableItemList VariableItemList;

--- a/tests/compilation_stubs/gui/scene_manager.h
+++ b/tests/compilation_stubs/gui/scene_manager.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct SceneManager SceneManager;
+
+typedef struct {
+  uint8_t type;
+} SceneManagerEvent;
+
+typedef struct {
+  void (**on_enter_handlers)(void *context);
+  bool (**on_event_handlers)(void *context, SceneManagerEvent event);
+  void (**on_exit_handlers)(void *context);
+  size_t scene_num;
+} SceneManagerHandlers;
+
+typedef enum {
+  SceneManagerEventTypeCustom = 0,
+  SceneManagerEventTypeTick = 1,
+} SceneManagerEventType;

--- a/tests/compilation_stubs/gui/view_dispatcher.h
+++ b/tests/compilation_stubs/gui/view_dispatcher.h
@@ -1,0 +1,7 @@
+#pragma once
+
+typedef struct ViewDispatcher ViewDispatcher;
+
+typedef enum {
+  ViewDispatcherTypeFullscreen = 0,
+} ViewDispatcherType;

--- a/tests/compilation_stubs/lib/toolbox/stream/file_stream.h
+++ b/tests/compilation_stubs/lib/toolbox/stream/file_stream.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/tests/compilation_stubs/storage/storage.h
+++ b/tests/compilation_stubs/storage/storage.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define EXT_PATH(path) path
+
+#define FSE_OK 0
+#define FSAM_READ 0
+#define FSAM_WRITE 1
+#define FSOM_OPEN_EXISTING 0
+#define FSOM_CREATE_ALWAYS 1
+
+typedef struct Storage Storage;
+typedef struct File File;
+
+typedef struct {
+  uint64_t size;
+} FileInfo;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+bool storage_file_exists(Storage *storage, const char *path);
+File *storage_file_alloc(Storage *storage);
+void storage_file_free(File *file);
+bool storage_file_open(File *file, const char *path, int access_mode,
+                       int open_mode);
+void storage_file_close(File *file);
+uint16_t storage_file_read(File *file, void *buffer, uint16_t length);
+uint16_t storage_file_write(File *file, const void *buffer, uint16_t length);
+int storage_common_stat(Storage *storage, const char *path, FileInfo *info);
+int storage_simply_mkdir(Storage *storage, const char *path);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/compile.sh
+++ b/tests/compile.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STUB_DIR="${ROOT_DIR}/tests/compilation_stubs"
+SOURCE_FILE="${ROOT_DIR}/flipper/flipper-evil-portal/helpers/evil_portal_storage.c"
+
+gcc -std=c11 -Wall -Wextra -Werror \
+    -I"${STUB_DIR}" \
+    -I"${ROOT_DIR}/flipper/flipper-evil-portal" \
+    -fsyntax-only "${SOURCE_FILE}"


### PR DESCRIPTION
## Summary
- load an optional failed.html on the Flipper and forward it to the ESP32 alongside index.html
- extend the ESP32 captive portal to host /failed.html and redirect submissions there when available
- generalize the command queue so setfailed and setap are sent sequentially after acknowledgements
- harden portal asset ownership on the Flipper so optional HTML/AP strings are duplicated, freed safely, and default gracefully when missing
- add a gcc-based compile smoke test with stubbed SDK headers to verify the storage helper builds in isolation

## Testing
- tests/compile.sh


------
https://chatgpt.com/codex/tasks/task_e_68c99279ec58832eb37e8c79b81f59b0